### PR TITLE
Update build script for Docker image management and cargo installation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,14 @@ PLATFORM=linux/$(uname -m)
 mkdir -p target/${PLATFORM##*/}
 mkdir -p ${PLATFORM}
 
+# Build wild
+echo "Building wild..."
+docker run \
+    -v "$(pwd)/target/${PLATFORM##*/}:/work" \
+    "rust-ubuntu:$DIST-$VERSION" \
+    cargo install --target-dir=/work --locked --bin --git https://github.com/davidlattimore/wild.git wild
+cp "target/${PLATFORM##*/}/release/wild" "${PLATFORM}/"
+
 # Build cargo-deb
 echo "Building cargo-deb..."
 docker run \

--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ mkdir -p ${PLATFORM}
 echo "Building wild..."
 docker run \
     -v "$(pwd)/target/${PLATFORM##*/}:/work" \
-    "rust-ubuntu:$DIST-$VERSION" \
+    "ghcr.io/yasuyuky/rust-ubuntu:$DIST-$VERSION" \
     cargo install --target-dir=/work --locked --bin --git https://github.com/davidlattimore/wild.git wild
 cp "target/${PLATFORM##*/}/release/wild" "${PLATFORM}/"
 
@@ -42,7 +42,7 @@ cp "target/${PLATFORM##*/}/release/wild" "${PLATFORM}/"
 echo "Building cargo-deb..."
 docker run \
     -v "$(pwd)/target/${PLATFORM##*/}:/work" \
-    "rust-ubuntu:$DIST-$VERSION" \
+    "ghcr.io/yasuyuky/rust-ubuntu:$DIST-$VERSION" \
     cargo install --target-dir=/work cargo-deb
 cp "target/${PLATFORM##*/}/release/cargo-deb" "${PLATFORM}/"
 
@@ -50,7 +50,7 @@ cp "target/${PLATFORM##*/}/release/cargo-deb" "${PLATFORM}/"
 echo "Building sccache..."
 docker run \
     -v "$(pwd)/target/${PLATFORM##*/}:/work" \
-    "rust-ubuntu:$DIST-$VERSION" \
+    "ghcr.io/yasuyuky/rust-ubuntu:$DIST-$VERSION" \
     cargo install --target-dir=/work sccache
 cp "target/${PLATFORM##*/}/release/sccache" "${PLATFORM}/"
 

--- a/build.sh
+++ b/build.sh
@@ -57,10 +57,5 @@ docker buildx build \
     --load \
     -f tools/Dockerfile .
 
-echo "Successfully built images:"
-echo "- rust-ubuntu:$DIST-$VERSION (base image)"
-echo "- rust-ubuntu:$DIST-$VERSION-tools (image with cargo-deb and sccache)"
-echo ""
-echo "You can run them with:"
-echo "docker run -it rust-ubuntu:$DIST-$VERSION"
-echo "docker run -it rust-ubuntu:$DIST-$VERSION-tools"
+echo "Successfully built the image:"
+echo " ghcr.io/yasuyuky/rust-ubuntu:$DIST-$VERSION"

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ echo "Building base image..."
 docker buildx build \
     --platform linux/$(uname -m) \
     --build-arg "dist=$DIST" \
-    --tag "rust-ubuntu:$DIST-$VERSION" \
+    --tag "ghcr.io/yasuyuky/rust-ubuntu:$DIST-$VERSION" \
     --load \
     .
 
@@ -53,7 +53,7 @@ docker buildx build \
     --build-arg "TARGETPLATFORM=${PLATFORM}" \
     --build-arg "dist=${DIST}" \
     --build-arg "ver=${VERSION}" \
-    --tag "rust-ubuntu:$DIST-$VERSION-tools" \
+    --tag "ghcr.io/yasuyuky/rust-ubuntu:$DIST-$VERSION" \
     --load \
     -f tools/Dockerfile .
 


### PR DESCRIPTION
Refactor the build script to utilize GitHub Container Registry for Docker images, simplify output, and add a step for installing the 'wild' cargo package.