### PR TITLE
Enhance architecture support in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,19 @@ jobs:
           branch: ${{ github.ref }}
 
   build-push:
-    runs-on: ubuntu-latest
     needs: release
     strategy:
       matrix:
         os: [focal, jammy, noble]
+        arch_group: [x86, arm]
+        include:
+          - arch_group: x86
+            runner: ubuntu-latest
+            platforms: linux/amd64
+          - arch_group: arm
+            runner: ubuntu-24.04-arm
+            platforms: linux/arm64,linux/arm/v7
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v5
       - name: Generate Dockerfile
@@ -65,19 +73,26 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ matrix.platforms }}
           build-args: dist=${{ matrix.os }}
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ needs.release.outputs.version }}
 
   build-tools:
-    runs-on: ubuntu-latest
     needs: [release, build-push]
     outputs:
       version: ${{ steps.generate-key.outputs.key }}
     strategy:
       matrix:
         platform: [linux/amd64, linux/arm64, linux/arm/v7]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - platform: linux/arm/v7
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -108,11 +123,19 @@ jobs:
           compression-level: 0
 
   install-tools:
-    runs-on: ubuntu-latest
     needs: [release, build-tools]
     strategy:
       matrix:
         os: [focal, jammy, noble]
+        arch_group: [x86, arm]
+        include:
+          - arch_group: x86
+            runner: ubuntu-latest
+            platforms: linux/amd64
+          - arch_group: arm
+            runner: ubuntu-24.04-arm
+            platforms: linux/arm64,linux/arm/v7
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/download-artifact@v5
@@ -136,7 +159,7 @@ jobs:
         with:
           context: ./tools
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ matrix.platforms }}
           build-args: |
             dist=${{ matrix.os }}
             ver=${{ needs.release.outputs.version }}
@@ -147,7 +170,7 @@ jobs:
         with:
           context: ./tools
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ matrix.platforms }}
           build-args: |
             dist=${{ matrix.os }}
             ver=${{ needs.release.outputs.version }}


### PR DESCRIPTION
Improve the build matrix to support architecture-specific runners and platforms for the build-push, build-tools, and install-tools jobs. This change allows for better differentiation between x86 and arm architectures during the release process.